### PR TITLE
WW-1077 video feedbacks

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -1,9 +1,8 @@
 <template>
     <div class="ww-video-youtube" :class="{ editing: isEditing }">
-        <div ref="videoPlayer"></div>
+        <div ref="videoPlayer" :key="componentKey"></div>
     </div>
 </template>
-
 
 <script>
 import YouTubePlayer from 'youtube-player';
@@ -41,6 +40,7 @@ export default {
     data() {
         return {
             timeUpdater: null,
+            componentKey: 0,
         };
     },
     computed: {
@@ -99,12 +99,24 @@ export default {
             if (this.player) await this.player.destroy();
 
             const el = this.$refs.videoPlayer;
+
             this.player = await YouTubePlayer(el, {
                 videoId: this.videoId,
                 playerVars: {
+                    playlist: this.videoId,
                     controls: this.content.controls ? 1 : 0,
+                    loop: this.content.loop ? 1 : 0,
                 },
             });
+
+            // if (this.content.loop) {
+            //     const playlist = `&playlist=${this.videoId}`;
+            //     const iframe = await this.player.getIframe();
+
+            //     iframe.src = iframe.src + playlist;
+
+            //     this.componentKey += 1;
+            // }
 
             this.player.on('ready', async () => {
                 if (this.content.muted) this.player.mute();
@@ -173,7 +185,6 @@ export default {
 };
 </script>
 
-
 <style lang="scss">
 .ww-video-youtube {
     position: relative;
@@ -195,5 +206,3 @@ export default {
     }
 }
 </style>
-
-

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="ww-video-youtube" :class="{ editing: isEditing }">
-        <div ref="videoPlayer" :key="componentKey"></div>
+        <div ref="videoPlayer"></div>
     </div>
 </template>
 
@@ -40,7 +40,6 @@ export default {
     data() {
         return {
             timeUpdater: null,
-            componentKey: 0,
         };
     },
     computed: {
@@ -73,9 +72,6 @@ export default {
         'content.controls'() {
             this.initPlayer();
         },
-        'content.loop'(value) {
-            if (this.player) this.player.setLoop(value);
-        },
         'content.muted'(value) {
             if (this.player) {
                 if (value) {
@@ -103,24 +99,12 @@ export default {
             this.player = await YouTubePlayer(el, {
                 videoId: this.videoId,
                 playerVars: {
-                    playlist: this.videoId,
                     controls: this.content.controls ? 1 : 0,
-                    loop: this.content.loop ? 1 : 0,
                 },
             });
 
-            // if (this.content.loop) {
-            //     const playlist = `&playlist=${this.videoId}`;
-            //     const iframe = await this.player.getIframe();
-
-            //     iframe.src = iframe.src + playlist;
-
-            //     this.componentKey += 1;
-            // }
-
             this.player.on('ready', async () => {
                 if (this.content.muted) this.player.mute();
-                if (this.content.loop) this.player.setLoop(true);
 
                 /* wwEditor:start */
                 // Get the video duration to adapt the option of videoStartTime
@@ -164,6 +148,8 @@ export default {
                                 name: 'end',
                                 event: { value: await this.player.getCurrentTime() },
                             });
+
+                            if (this.content.loop) await this.player.seekTo(0);
                             break;
                         default:
                             break;


### PR DESCRIPTION
Compliqué à trouver celui-ci...
En fait, les vidéos Youtube ne peuvent pas être elle-même "loopé". Il faut qu'elles soient dans une playlist qui elle est configurée à `loop: true`
Sauf que la librairie que j'ai utilisée ne supporte pas les playlists et c'est pas clair

Du coup pour contourner le souci, lorsque la vidéo est terminée et que l'event se trigger, si `content.loop = true`, je "seek to 0sec"